### PR TITLE
Fixing deprecation warnings regarding bare variables and apt

### DIFF
--- a/roles/adduser/tasks/main.yml
+++ b/roles/adduser/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: User | Create User Group
   group: name={{item.group|default(item.name)}} system={{item.system|default(omit)}}
-  with_items: addusers
+  with_items: "{{ addusers }}"
 
 - name: User | Create User
   user:
@@ -25,4 +25,4 @@
     home: "{{item.home|default(omit)}}"
     name: "{{item.name}}"
     system: "{{item.system|default(omit)}}"
-  with_items: addusers
+  with_items: "{{ addusers }}"

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -47,7 +47,7 @@
     resource: "{{item.item.type}}"
     filename: /etc/kubernetes/{{item.item.file}}
     state: "{{item.changed | ternary('latest','present') }}"
-  with_items: manifests.results
+  with_items: "{{ manifests.results }}"
   when: inventory_hostname == groups['kube-master'][0]
 
 - name: Check for dnsmasq port (pulling image and running container)

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -28,14 +28,14 @@
     id: "{{item}}"
     keyserver: "{{docker_repo_key_info.keyserver}}"
     state: present
-  with_items: docker_repo_key_info.repo_keys
+  with_items: "{{ docker_repo_key_info.repo_keys }}"
 
 - name: ensure docker repository is enabled
   action: "{{ docker_repo_info.pkg_repo }}"
   args:
     repo: "{{item}}"
     state: present
-  with_items: docker_repo_info.repos
+  with_items: "{{ docker_repo_info.repos }}"
   when: docker_repo_info.repos|length > 0
 
 - name: ensure docker packages are installed
@@ -43,7 +43,7 @@
   args:
     pkg: "{{item}}"
     state: present
-  with_items: docker_package_info.pkgs
+  with_items: "{{ docker_package_info.pkgs }}"
   when: docker_package_info.pkgs|length > 0
 
 - name: Centos needs xfs storage type for devicemapper if used

--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create dest directories
   file: path={{local_release_dir}}/{{item.dest|dirname}} state=directory recurse=yes
-  with_items: downloads
+  with_items: "{{ downloads }}"
 
 - name: Download items
   get_url:
@@ -10,7 +10,7 @@
     sha256sum: "{{item.sha256 | default(omit)}}"
     owner: "{{ item.owner|default(omit) }}"
     mode: "{{ item.mode|default(omit) }}"
-  with_items: downloads
+  with_items: "{{ downloads }}"
 
 - name: Extract archives
   unarchive:
@@ -20,7 +20,7 @@
     mode: "{{ item.mode|default(omit) }}"
     copy: no
   when: "{{item.unarchive is defined and item.unarchive == True}}"
-  with_items: downloads
+  with_items: "{{ downloads }}"
 
 - name: Fix permissions
   file:
@@ -29,4 +29,4 @@
     owner: "{{ item.owner|default(omit) }}"
     mode: "{{ item.mode|default(omit) }}"
   when: "{{item.unarchive is not defined or item.unarchive == False}}"
-  with_items: downloads
+  with_items: "{{ downloads }}"

--- a/roles/kubernetes/master/tasks/main.yml
+++ b/roles/kubernetes/master/tasks/main.yml
@@ -45,7 +45,7 @@
 - meta: flush_handlers
 
 - include: start.yml
-  with_items: groups['kube-master']
+  with_items: "{{ groups['kube-master'] }}"
   when: "{{ hostvars[item].inventory_hostname == inventory_hostname }}"
 
 # Create kube-system namespace

--- a/roles/kubernetes/preinstall/tasks/etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/etchosts.yml
@@ -8,7 +8,7 @@
     create: yes
     backup: yes
   when: hostvars[item].ansible_default_ipv4.address is defined
-  with_items: groups['all']
+  with_items: "{{ groups['all'] }}"
 
 - name: Hosts | populate kubernetes loadbalancer address into hosts file
   lineinfile:

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -68,12 +68,12 @@
 - name: Install latest version of python-apt for Debian distribs
   apt: name=python-apt state=latest update_cache=yes cache_valid_time=3600
   when: ansible_os_family == "Debian"
-  changed_when: False
 
 - name: Install python-dnf for latest RedHat versions
   command: dnf install -y python-dnf yum
   when: ansible_distribution == "Fedora" and
         ansible_distribution_major_version > 21
+  changed_when: False
 
 - name: Install epel-release on RHEL
   command: rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm

--- a/roles/kubernetes/preinstall/tasks/main.yml
+++ b/roles/kubernetes/preinstall/tasks/main.yml
@@ -61,16 +61,12 @@
     - "/opt/cni/bin"
   when: kube_network_plugin == "calico"
 
-- name: Update package management cache (APT)
-  apt: update_cache=yes
-  when: ansible_pkg_mgr == 'apt'
-
 - name: Update package management cache (YUM)
   yum: update_cache=yes name='*'
   when: ansible_pkg_mgr == 'yum'
 
-- name: Install python-apt for Debian distribs
-  command: apt-get install -y python-apt
+- name: Install latest version of python-apt for Debian distribs
+  apt: name=python-apt state=latest update_cache=yes cache_valid_time=3600
   when: ansible_os_family == "Debian"
   changed_when: False
 
@@ -78,7 +74,6 @@
   command: dnf install -y python-dnf yum
   when: ansible_distribution == "Fedora" and
         ansible_distribution_major_version > 21
-  changed_when: False
 
 - name: Install epel-release on RHEL
   command: rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm

--- a/roles/kubernetes/secrets/tasks/gen_certs.yml
+++ b/roles/kubernetes/secrets/tasks/gen_certs.yml
@@ -48,4 +48,4 @@
   file:
     path: "{{ item }}"
     mode: 0600
-  with_items: keyfiles.stdout_lines
+  with_items: "{{ keyfiles.stdout_lines }}"


### PR DESCRIPTION
This fixes a few deprecation warnings regarding bare variables like:

    [DEPRECATION WARNING]: Using bare variables is deprecated.
    Update your playbooks so that the environment value uses the full
    variable syntax ('{{keyfiles.stdout_lines}}'). This feature will be
    removed in a future release. Deprecation warnings can be disabled
    by setting deprecation_warnings=False in ansible.cfg.

On debian based systems python-apt will be installed using the apt module instead of the command module to fix a warning regarding apt.